### PR TITLE
[fix] Remove Google OAuth description

### DIFF
--- a/front-end/src/routes/auth/sign-in/+page.svelte
+++ b/front-end/src/routes/auth/sign-in/+page.svelte
@@ -12,6 +12,6 @@
 
 <div class="flex flex-col space-y-2 text-center">
 	<h1 class="text-2xl font-semibold tracking-tight">Sign In</h1>
-	<p class="text-muted-foreground text-sm">Sign-in to your account with Google OAuth</p>
+	<p class="text-muted-foreground text-sm">Sign-in to your account</p>
 </div>
 <UserAuthForm class={undefined} supabase={data.supabase} />


### PR DESCRIPTION
## Changes

- Removed "with Google OAuth" line at the email login section; there is already a "Or continue with" section below it.