### PR TITLE
[fix] Remove erroneous null string message in Username form field.

### DIFF
--- a/front-end/src/lib/api/models.ts
+++ b/front-end/src/lib/api/models.ts
@@ -8,7 +8,7 @@ export interface User {
 
 export interface UserUpdate {
 	email: string;
-	username?: string;
+	username?: string | null;
 	channel_push?: boolean;
 	channel_email?: boolean;
 	notification_type?: 'all_notif' | 'book_updates_only' | 'no_notif';

--- a/front-end/src/lib/components/forms/user-settings.svelte
+++ b/front-end/src/lib/components/forms/user-settings.svelte
@@ -4,9 +4,13 @@
 	export const profileFormSchema = z.object({
 		username: z
 			.string()
-			.min(2, 'Username must be at least 2 characters.')
-			.max(30, 'Username must not be longer than 30 characters')
-			.optional(),
+			.refine((username) => username.length !== 1, {
+				message: 'Username must be at least 2 characters.'
+			})
+			.refine((username) => username.length <= 30, {
+				message: 'Username must not be longer than 30 characters.'
+			})
+			.nullish(),
 		email: z.string({ required_error: 'Please select an email to display' }).email(),
 		notification_type: z.enum(['all_notif', 'book_updates_only', 'no_notif']),
 		channel_push: z.boolean().default(true),


### PR DESCRIPTION
Removes this message when the field is empty on page load; where the user does not have a username yet.

![image](https://github.com/user-attachments/assets/12483f71-414b-4b57-8c30-fa116ccfcf52)
